### PR TITLE
add "use nqp" to appease recent rakudo

### DIFF
--- a/lib/IO/Path/More.pm
+++ b/lib/IO/Path/More.pm
@@ -2,6 +2,9 @@ use MONKEY_TYPING;
 use File::Find;
 use Shell::Command;
 
+# needed to prevent warning now;
+use nqp;
+
 ##### Functions for Export: path() variants ######
 # because Str.path is already taken by IO::Path
 multi sub path (Str:D $path) is export {


### PR DESCRIPTION
Hi,
in the last couple of weeks using "nqp::" functions without first doing "use nqp" became deprecated.

The long term solution is probably to fix IO to have the appropriate methods itself I guess.