### PR TITLE
Fix fallout from the operator chaining change

### DIFF
--- a/lib/IO/Path/More.pm
+++ b/lib/IO/Path/More.pm
@@ -68,7 +68,7 @@ method next {
         @dir[0];
     }
     else {
-        first { self.basename leg $_ ~~ Less }, @dir.sort;
+        first { (self.basename leg $_ ) ~~ Less }, @dir.sort;
     }
 }
 
@@ -83,7 +83,7 @@ method previous {
         $previtem;
     }
     else {
-        first { self.basename leg $_ ~~ More }, @dir.sort.reverse;
+        first { ( self.basename leg $_ ) ~~ More }, @dir.sort.reverse;
     }
 }
 


### PR DESCRIPTION
The commit

https://github.com/rakudo/rakudo/commit/81ad2c0db9910fe7093c1db1d0e25e4710f3e67e

means you can't chain  various operators in quite the same way as before.