### PR TITLE
done -> done-testing

### DIFF
--- a/t/00-more.t
+++ b/t/00-more.t
@@ -47,5 +47,5 @@ if $*DISTRO.name ne any( <MSWin32 dos VMS MacOS> ) {
 }
 else { skip "all unix tests for now", 2; }
 
-done;
+done-testing;
 


### PR DESCRIPTION
with the introduction of 'done' as a keyword, it no longer operates as a synonym for done-testing